### PR TITLE
length validation of category description

### DIFF
--- a/BlogEngine/BlogEngine.NET/admin/app/content/categories/categoryController.js
+++ b/BlogEngine/BlogEngine.NET/admin/app/content/categories/categoryController.js
@@ -80,7 +80,8 @@
         bindCommon();
         $('#form').validate({
             rules: {
-                txtSlug: { required: true }
+                txtSlug: { required: true },
+                txtExcerpt: { maxlength: 200 }
             }
         });
     });


### PR DESCRIPTION
As noted in #59 the length of the description field in category table on db provider is 200 characters.
This validates the description input, not allowing more of that characters.