### PR TITLE
Metaweblog api doesn't change creation date of the post if none is selected on edit mode

### DIFF
--- a/BlogEngine/BlogEngine.Core/API/MetaWeblog/MetaWeblogHandler.cs
+++ b/BlogEngine/BlogEngine.Core/API/MetaWeblog/MetaWeblogHandler.cs
@@ -329,8 +329,10 @@
             post.IsPublished = publish;
             post.Slug = sentPost.slug;
             post.Description = sentPost.excerpt;
-            post.DateCreated = sentPost.postDate;
-
+            if (!(sentPost.postDate == DateTime.MinValue))
+            {
+                post.DateCreated = sentPost.postDate;
+            }
             if (sentPost.commentPolicy != string.Empty)
             {
                 post.HasCommentsEnabled = sentPost.commentPolicy == "1";

--- a/BlogEngine/BlogEngine.Core/API/MetaWeblog/MetaWeblogHandler.cs
+++ b/BlogEngine/BlogEngine.Core/API/MetaWeblog/MetaWeblogHandler.cs
@@ -329,10 +329,12 @@
             post.IsPublished = publish;
             post.Slug = sentPost.slug;
             post.Description = sentPost.excerpt;
+
             if (!(sentPost.postDate == DateTime.MinValue))
             {
                 post.DateCreated = sentPost.postDate;
             }
+
             if (sentPost.commentPolicy != string.Empty)
             {
                 post.HasCommentsEnabled = sentPost.commentPolicy == "1";


### PR DESCRIPTION
This fixes #30.
If no date is selected on editing a post trough metaweblog api, the new post object date stays at its initial constructed value (DateTime.MinValue).
So if that is the case the post preserves its original creation date.